### PR TITLE
[FIX] Fix unsupported runtime compilation of Vue

### DIFF
--- a/resources/js/Booking/booking.js
+++ b/resources/js/Booking/booking.js
@@ -1,7 +1,7 @@
 require("./bootstrap");
 import axios from 'axios';
 // import Vue from 'vue';
-import { createApp } from 'vue';
+import { createApp } from "vue/dist/vue.esm-bundler";
 import Dropzone from 'dropzone';
 
 function initTippy() {


### PR DESCRIPTION
Component provided template option but runtime compilation is not supported in this build of Vue.

Reference : [Unsupported Runtime Compilation of Vue](https://laracasts.com/discuss/channels/vue/component-provided-template-option-but-runtime-compilation-is-not-supported-in-this-build-of-vue)